### PR TITLE
bugfix can not load favicon.ico in dashboard

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -23,7 +23,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Apache ShenYu Gateway</title>
-  <link rel="icon" href="/favicon.png" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
 </head>
 
 <body>


### PR DESCRIPTION
bugfix can not load favicon.ico in dashboard

change warong `favicon.png` to `favicon.ico`

before:

<img width="342" alt="2023-05-03 14 52 00" src="https://user-images.githubusercontent.com/24788200/235849157-6846c605-e72b-4f74-b73e-8aacabd6afae.png">

after:

<img width="325" alt="2023-05-03 14 53 10" src="https://user-images.githubusercontent.com/24788200/235849330-233db7c2-79c1-4364-b8f1-6b13c78cc17c.png">

please help to review @yu199195 
