### PR TITLE
fix password rule that it not think =_+- are special characters

### DIFF
--- a/src/components/GlobalHeader/index.js
+++ b/src/components/GlobalHeader/index.js
@@ -233,7 +233,7 @@ class GlobalHeader extends PureComponent {
                         );
                         return;
                       }
-                      if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/.test(value)) {
+                      if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&=_+-])[A-Za-z\d@$!%*?&=_+-]{8,}$/.test(value)) {
                         callback(
                           getIntlContent("SHENYU.GLOBALHEADER.PASSWORD.RULE")
                         );


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

- fix password rule that it not think =_+- are special characters

password rule is `Minimum length of 8, including upper and lower case letters, numbers and special characters`
 
The password eg: `123YSH=abc` `123YSH_abc` `123YSH-abc` `123YSH+abc` can not pass the password rule now due the rule think ` =_+-` are not special characters. 

But the characters `=_+-` are password special characters that we use frequently. User can not find what the problem when them use this characters to change password.     

before: 
<img width="734" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/24788200/7e8cf3f4-6745-42a1-8259-178966e1dd01">

after: 

<img width="722" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/24788200/83135409-b175-4b63-9729-59c66d06fef4">

