### PR TITLE
fixbug/plugin-status

### DIFF
--- a/src/routes/Plugin/Common/index.js
+++ b/src/routes/Plugin/Common/index.js
@@ -254,7 +254,8 @@ export default class Common extends Component {
   togglePluginStatus = () => {
     const { dispatch, plugins } = this.props;
     const pluginName = this.props.match.params ? this.props.match.params.id : "";
-    const { name, id, role, config, sort, file} = this.getPlugin(plugins, pluginName);
+    const plugin = this.getPlugin(plugins, pluginName)
+    const { name, id, role, config, sort, file} = plugin;
     const enabled = !this.state.isPluginEnabled
     const enabledStr = enabled ? '1' : '0';
     dispatch({
@@ -273,6 +274,7 @@ export default class Common extends Component {
         enabled: enabledStr
       },
       callback: () => {
+        plugin.enabled = enabled;
         this.setState({ isPluginEnabled: enabled })
         this.closeModal();
       }


### PR DESCRIPTION
about #304 

>  Note: This fix is not a final solution, and does not guarantee that the status of the list page will be synchronized with the detail page after modification, and users need to refresh the page to avoid it


Reason: The plug-in information used on the plug-in page is not the latest information (user memory), and it needs to be updated by switching the menu, which involves the overall plan optimization


Temporary circumvention: Switch state to synchronously modify the user memory plug-in state

