### PR TITLE
fix password rules, add special characters '#' and '.'

### DIFF
--- a/src/components/GlobalHeader/index.js
+++ b/src/components/GlobalHeader/index.js
@@ -233,7 +233,7 @@ class GlobalHeader extends PureComponent {
                         );
                         return;
                       }
-                      if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&=_+-])[A-Za-z\d@$!%*?&=_+-]{8,}$/.test(value)) {
+                      if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&#.=_+-])[A-Za-z\d@$!%*?&#.=_+-]{8,}$/.test(value)) {
                         callback(
                           getIntlContent("SHENYU.GLOBALHEADER.PASSWORD.RULE")
                         );


### PR DESCRIPTION
* fix password rules, add special characters # and .

password rule is Minimum length of 8, including upper and lower case letters, numbers and special characters

The password eg: ShenYu#=123 ShenYu=.123 can not pass the password rule now due the rule think #. are not special characters.

But the characters #. are password special characters that we use frequently. User can not find what the problem when them use this characters to change password.
before:
![1](https://github.com/apache/shenyu-dashboard/assets/33129823/0bfa0159-473b-47cc-9326-767703a962a2)
after:
![2](https://github.com/apache/shenyu-dashboard/assets/33129823/8def697d-847e-4901-8b9b-99bc532efafb)


This is my inaugural pull request (PR) submission. I used https://github.com/apache/shenyu-dashboard/pull/287 as a reference for the formatting. If there are any areas that require refinement, I am committed to making prompt adjustments.