### PR TITLE
Support `isBlank`

### DIFF
--- a/src/routes/Plugin/Common/Rule.js
+++ b/src/routes/Plugin/Common/Rule.js
@@ -124,7 +124,7 @@ class AddModal extends Component {
     if (ruleConditions) {
       ruleConditions.forEach((item, index) => {
         const { paramType, operator, paramName, paramValue } = item;
-        if (!paramType || !operator || !paramValue) {
+        if (!paramType || !operator || (operator !== "isBlank" && !paramValue)) {
           message.destroy();
           message.error(`Line ${index + 1} condition is incomplete`);
           result = false;
@@ -338,6 +338,11 @@ class AddModal extends Component {
           return operate.key !== "pathPattern" ? operate : ""
         })
       }
+      if (paramType !== "post" && paramType !== "query" && paramType !== "header" && paramType !== "cookie") {
+        operatorsFil = operatorsFil.filter(operate => {
+          return operate.key !== "isBlank" ? operate : ""
+        })
+      }
       if (paramType === "uri" || paramType === "host" || paramType === "ip" || paramType === "cookie" || paramType === "domain") {
         operatorsFil = operatorsFil.filter(operate => {
           return operate.key !== "TimeBefore" && operate.key !== "TimeAfter" ? operate : ""
@@ -395,7 +400,12 @@ class AddModal extends Component {
             );
           }}
           value={item.paramValue}
-          style={{ width: 160 }}
+          style={{
+            width: 160,
+            display: item.operator === "isBlank"
+              ? "none"
+              : "block"
+          }}
         />
       )
     }

--- a/src/routes/Plugin/Common/Selector.js
+++ b/src/routes/Plugin/Common/Selector.js
@@ -161,7 +161,7 @@ class AddModal extends Component {
     if (selectorConditions) {
       selectorConditions.forEach((item, index) => {
         const { paramType, operator, paramName, paramValue } = item;
-        if (!paramType || !operator || !paramValue) {
+        if (!paramType || !operator || (operator !== "isBlank" && !paramValue)) {
           message.destroy();
           message.error(`Line ${index + 1} condition is incomplete`);
           result = false;
@@ -777,6 +777,11 @@ class AddModal extends Component {
           return operate.key !== "pathPattern" ? operate : ""
         })
       }
+      if (paramType !== "post" && paramType !== "query" && paramType !== "header" && paramType !== "cookie") {
+        operatorsFil = operatorsFil.filter(operate => {
+          return operate.key !== "isBlank" ? operate : ""
+        })
+      }
       if (paramType === "uri" || paramType === "host" || paramType === "ip" || paramType === "cookie" || paramType === "domain") {
         operatorsFil = operatorsFil.filter(operate => {
           return operate.key !== "TimeBefore" && operate.key !== "TimeAfter" ? operate : ""
@@ -1042,7 +1047,14 @@ class AddModal extends Component {
                           </Select>
                         </Col>
 
-                        <Col span={7}>
+                        <Col
+                          span={7}
+                          style={{
+                            display: item.operator === "isBlank"
+                              ? "none"
+                              : "block"
+                          }}
+                        >
                           <Tooltip title={item.paramValue}>
                             {this.getParamValueInput(item, index)}
                           </Tooltip>


### PR DESCRIPTION
It is the frontend support of this backend PR: apache/shenyu#4983  
* When `isBlank` is selected, Value hides & does not judge the value;
* Only [`post`, 'query', 'header', 'cookie'] supports `isBlank`;