### PR TITLE
API-Debug page request result exception compatible handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-container-query": "^0.11.0",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.13.1",
+    "react-html-parser": "^2.0.2",
     "react-intl-universal": "^2.4.2",
     "react-json-view": "^1.21.3",
     "react-resizable": "^1.11.0",

--- a/src/routes/Document/components/ApiDebug.js
+++ b/src/routes/Document/components/ApiDebug.js
@@ -18,6 +18,7 @@
 import {Button, Col, Empty, Form, Icon, Input, message, Row, Select, Tabs, Typography} from "antd";
 import React, {createRef, forwardRef, useContext, useEffect, useImperativeHandle, useState} from "react";
 import ReactJson from "react-json-view";
+import ReactHtmlParser from "react-html-parser";
 import fetch from "dva/fetch";
 import {
   createOrUpdateMockRequest,
@@ -359,12 +360,22 @@ function ApiDebug() {
       },
       body: JSON.stringify(params)
     }).then(async response => {
-      const data = await response.json();
+      const textData = await response.text();
+      let jsonData = null;
+      let type = 'text';
+      try {
+        jsonData = JSON.parse(textData);
+        type = 'json';
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
       setResponseInfo({
         "sandbox-params": response.headers.get("sandbox-params"),
         "sandbox-beforesign": response.headers.get("sandbox-beforesign"),
         "sandbox-sign": response.headers.get("sandbox-sign"),
-        body: data
+        body: type === 'json' ? jsonData : textData,
+        bodyType: type
       });
     });
   };
@@ -421,9 +432,9 @@ function ApiDebug() {
           tab={getIntlContent("SHENYU.DOCUMENT.APIDOC.INFO.REQUEST.RESULTS")}
           key="2"
         >
-          {Object.keys(responseInfo).length ? (
+          {responseInfo.bodyType === 'json' && Object.keys(responseInfo).length ? (
             <ReactJson src={responseInfo.body} name={false} />
-          ) : (
+          ) : responseInfo.body ? ReactHtmlParser(responseInfo.body) : (
             <Empty description={false} />
           )}
         </TabPane>


### PR DESCRIPTION
There are several types of responses when API-Debug:  
* JSON  
![image](https://github.com/apache/shenyu-dashboard/assets/3371163/18300039-a30c-4349-8fb6-87d7fdce67b7)   
* TEXT  
![image](https://github.com/apache/shenyu-dashboard/assets/3371163/6cf48eb8-bede-4347-9e07-52e5d481538f)   
* HTML  
![image](https://github.com/apache/shenyu-dashboard/assets/3371163/152b7312-556f-4fde-a5dc-f005d409664e)   

-----  

Before:  
> Only JSON is supported  

![文档调试页更新前 gif](https://github.com/apache/shenyu-dashboard/assets/3371163/890975d3-8dc5-48d5-9310-078cc1fc2d1a)

After:  
> Support all formats of response, JSON with JSON-View, other unified with HTML-View  

![文档调试页更新后 gif](https://github.com/apache/shenyu-dashboard/assets/3371163/bdf7e1e2-93a0-4377-b0f7-1c5ae87257c1)

