### PR TITLE
Update index.js

### DIFF
--- a/src/routes/System/Plugin/index.js
+++ b/src/routes/System/Plugin/index.js
@@ -313,7 +313,14 @@ export default class Plugin extends Component {
             },
             fetchValue: this.currentQueryPayload(),
             callback: () => {
-              this.setState({ selectedRowKeys: [] });
+              this.setState({ selectedRowKeys: [] }, () => {
+                dispatch({
+                  type: "global/fetchPlugins",
+                  payload: {
+                    callback: () => {}
+                  }
+                });
+              });
             }
           });
         }


### PR DESCRIPTION
Before:   
> Edit the plug-status on the `/config/plugin` page, and then switch to the `/plug/XXX` page. The status is not updated, and the page needs to be refreshed manually  

![image](https://github.com/apache/shenyu-dashboard/assets/3371163/544a04d0-1cda-49c3-91a3-0d3855abed63)

After:   
> Automatically refresh global data after editing status on the `/config/plugin` page  

![image](https://github.com/apache/shenyu-dashboard/assets/3371163/1172c225-c9f7-4561-b553-532d3c3a58a7)
