### PR TITLE
fixed #329

### DIFF
--- a/src/routes/Document/components/ApiDebug.js
+++ b/src/routes/Document/components/ApiDebug.js
@@ -35,7 +35,20 @@ import {Method} from "./globalData";
 const { Title, Text, Paragraph } = Typography;
 const { TabPane } = Tabs;
 const FormItem = Form.Item;
-const InputGroup = Input.Group
+const InputGroup = Input.Group;
+
+const objectToArray = (obj) => {
+  return Object.keys(obj ?? {}).map((key, index) => ({index, key, value: obj[key]}));
+}
+
+const arrayToObject = (arr) => {
+  return (arr ?? []).reduce((acc, curr) => {
+    if (curr.key) {
+      acc[curr.key] = curr.value;
+    }
+    return acc;
+  }, {});
+}
 
 const FCForm = forwardRef(({ form, onSubmit }, ref) => {
   useImperativeHandle(ref, () => ({
@@ -56,13 +69,13 @@ const FCForm = forwardRef(({ form, onSubmit }, ref) => {
     url: apiMock.url,
     pathVariable: apiMock.pathVariable,
     query: apiMock.query,
-    header: apiMock.header,
+    header: JSON.stringify(objectToArray(apiMock.header)),
     body: apiMock.body
   });
   const [activeKey, setActiveKey] = useState("1");
 
   const getDefaultHeaderByKey = (key) => {
-    return {"Content-Type": key === '1' ? "application/json" : "application/x-www-form-urlencoded"}
+    return objectToArray({"Content-Type": key === '1' ? "application/json" : "application/x-www-form-urlencoded"});
   }
 
   useEffect(
@@ -75,7 +88,7 @@ const FCForm = forwardRef(({ form, onSubmit }, ref) => {
         url: apiMock.url,
         pathVariable: apiMock.pathVariable,
         query: apiMock.query,
-        header: apiMock.header,
+        header: JSON.stringify(objectToArray(apiMock.header)),
         body: apiMock.body
       });
       form.resetFields("requestUrl");
@@ -192,7 +205,7 @@ const FCForm = forwardRef(({ form, onSubmit }, ref) => {
   const changeParamTab = (key) => {
     setActiveKey(key);
     let header = form.getFieldsValue().headers;
-    let headerJson = {...JSON.parse(header), ...getDefaultHeaderByKey(key)};
+    let headerJson = [...JSON.parse(header), ...getDefaultHeaderByKey(key)];
     setInitialValue({...initialValue, header: JSON.stringify(headerJson)});
   }
 
@@ -350,7 +363,7 @@ function ApiDebug() {
 
   const handleSubmit = async values => {
     const { headers, requestUrl, ...params } = values;
-    params.headers = JSON.parse(headers);
+    params.headers = arrayToObject(JSON.parse(headers));
     params.requestUrl = requestUrl;
     fetch(sandboxProxyGateway(), {
       method: "POST",

--- a/src/routes/Document/components/HeadersEditor.js
+++ b/src/routes/Document/components/HeadersEditor.js
@@ -22,45 +22,36 @@ const { Text } = Typography;
 
 function HeadersEditor(props) {
   const {value: propsValue, onChange, buttonText} = props;
-  const jsonObj = JSON.parse(propsValue || '{}');
-  const [value, onChangeValue] =useState(Object.keys(jsonObj).map((key, index) => ({index, key, value: jsonObj[key]})));
+  const jsonObj = JSON.parse(propsValue || '[]');
+  const [value, setValue] = useState(jsonObj);
 
   useEffect(
     () => {
-      onChangeValue(Object.keys(jsonObj).map((key, index) => ({index, key, value: jsonObj[key]})))
+      setValue(jsonObj)
     },
     [propsValue]
   );
 
   const onChangeItem = (e, key, index) => {
-    let newValue = value.map(
+    changeValue(value.map(
       item => (item.index === index ? { ...item, [key]: e } : item)
-    );
-    onChangeValue(newValue);
-    onChange(format(newValue));
+    ));
   };
 
   const onDeleteItem = key => {
-    let newValue = value.filter(item => item.key !== key);
-    onChangeValue(newValue);
-    onChange(format(newValue));
+    changeValue(value.filter(item => item.key !== key));
   };
 
   const onAddItem = () => {
-    let newValue = [
+    changeValue([
       ...value,
       {index: value.length, key: "", value: ""}
-    ];
-    onChangeValue(newValue);
-    onChange(format(newValue));
+    ]);
   };
 
-  const format = (param) => {
-    const newObject = param.reduce((acc, curr) => {
-      acc[curr.key] = curr.value;
-      return acc;
-    }, {});
-    return JSON.stringify(newObject);
+  const changeValue = (newValue) => {
+    setValue(newValue);
+    onChange(JSON.stringify(newValue));
   }
 
   return (


### PR DESCRIPTION
![头部编辑器已修复](https://github.com/apache/shenyu-dashboard/assets/3371163/ce8b9732-73e7-4182-a562-22969eabf3df)  
* HeadersEditor page, which unifies the working data structure into an array, maintains the data order of user operations, and improves the operation experience  
* ApiDebug page, do data conversion, only filtering invalid data at pass to the backend