### PR TITLE
[Bug] fix when not input query,HeadersEditor can not render

### DIFF
--- a/src/routes/Document/components/ApiDebug.js
+++ b/src/routes/Document/components/ApiDebug.js
@@ -120,7 +120,7 @@ const FCForm = forwardRef(({ form, onSubmit }, ref) => {
 
   useEffect(
     () => {
-      form.setFieldsValue({querys: initialValue.query || "{}"})
+      form.setFieldsValue({querys: initialValue.query || "[]"})
     },
     [initialValue.query]
   );


### PR DESCRIPTION
before:

1. 
<img width="1728" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/52746628/7b26b59a-1250-4708-98f6-a810a7a82eb0">

2. 
<img width="1728" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/52746628/8b497a6d-763b-4a01-946f-4cf0a96c434c">

now:

<img width="1728" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/52746628/dc2f1c52-a963-4d27-8920-4acc21149661">
