### PR TITLE
when api detail has not requestParameters, use parameters in document

### DIFF
--- a/src/routes/Document/components/ApiInfo.js
+++ b/src/routes/Document/components/ApiInfo.js
@@ -28,10 +28,10 @@ function ApiInfo(props) {
   const {
     apiData: { envProps = [] },
     apiDetail,
-    apiDetail: { document, requestParameters, responseParameters, requestHeaders }
+    apiDetail: { document, responseParameters, requestHeaders }
   } = useContext(ApiContext);
   const { handleUpdate, handleDelete } = props;
-
+  let requestParameters = apiDetail.requestParameters;
   let documentJSON = {};
   try {
     documentJSON = JSON.parse(document);
@@ -43,6 +43,7 @@ function ApiInfo(props) {
         content: documentJSON.responses[key].content
       });
     });
+    requestParameters = requestParameters??documentJSON.parameters
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(e);


### PR DESCRIPTION
https://github.com/apache/shenyu-dashboard/issues/302

before

<img width="1728" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/52746628/25e04700-d3db-4b9f-9b32-374976944aaa">

after

<img width="1728" alt="image" src="https://github.com/apache/shenyu-dashboard/assets/52746628/83f793f5-216e-484c-8633-71867e0ccecd">
