### PR TITLE
fix: fix the bug of changing the state during the render process and other small bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-intl-universal": "^2.4.2",
     "react-json-view": "^1.21.3",
     "react-resizable": "^1.11.0",
+    "react-router-dom": "^6.15.0",
     "redux-logger": "^3.0.6",
     "setprototypeof": "^1.1.0",
     "url-polyfill": "^1.0.10"

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -115,7 +115,8 @@ class BasicLayout extends React.PureComponent {
       localeName: window.sessionStorage.getItem("locale")
         ? window.sessionStorage.getItem("locale")
         : "en-US",
-      pluginsLoaded: false
+      pluginsLoaded: false,
+      processedMenus: []
     };
   }
 
@@ -135,6 +136,7 @@ class BasicLayout extends React.PureComponent {
       });
       return;
     }
+    this.processMenus()
     const { dispatch } = this.props;
     dispatch({
       type: "global/fetchPlatform"
@@ -216,19 +218,9 @@ class BasicLayout extends React.PureComponent {
     });
   };
 
-  render() {
-    const {
-      collapsed,
-      routerData,
-      match,
-      location,
-      plugins,
-      menuTree,
-      permissions,
-      dispatch
-    } = this.props;
-    const { localeName, pluginsLoaded } = this.state;
-    const bashRedirect = this.getBaseRedirect();
+  processMenus() {
+    const { plugins, menuTree, permissions, dispatch } = this.props
+    const { pluginsLoaded } = this.state
     let menus = getMenuData();
     if (menuTree.length > 0) {
       menus = menus.slice(0, 1);
@@ -308,13 +300,27 @@ class BasicLayout extends React.PureComponent {
       }
     });
 
+    this.setState({processedMenus: menus})
+  }
+
+  render() {
+    const {
+      collapsed,
+      routerData,
+      match,
+      location,
+      dispatch
+    } = this.props;
+    const { localeName, processedMenus } = this.state;
+    const bashRedirect = this.getBaseRedirect();
+
     const layout = (
       <Layout>
         <SiderMenu
           logo={logo}
           TitleLogo={TitleLogo}
           dispatch={dispatch}
-          menuData={menus}
+          menuData={processedMenus}
           collapsed={collapsed}
           location={location}
           onCollapse={this.handleMenuCollapse}

--- a/src/layouts/UserLayout.less
+++ b/src/layouts/UserLayout.less
@@ -22,7 +22,7 @@
   flex-direction: column;
   height: 100vh;
   overflow: auto;
-  background-image: url();
+  // background-image: url();
   background: #ffffff;
 }
 

--- a/src/routes/System/Plugin/index.js
+++ b/src/routes/System/Plugin/index.js
@@ -359,7 +359,7 @@ export default class Plugin extends Component {
           width: 120,
           render: (text, record) => {
             return record.url
-              ? <Link to={record.url}><div style={{color: "#1890ff", "fontWeight": "bold", "text-decoration-line": "underline"}}>{text || "----"}</div></Link>
+              ? <Link to={record.url}><div style={{color: "#1890ff", "fontWeight": "bold", "textDecorationLine": "underline"}}>{text || "----"}</div></Link>
               : <div style={{color: "#260033", "fontWeight": "bold"}}>{text || "----"}</div>;
           }
         },


### PR DESCRIPTION
This pr mainly fixes some bugs:

1. In our current code, the state is changed in the render function, thus causing the following warning：

![61693845199_ pic](https://github.com/apache/shenyu-dashboard/assets/116816752/a02c37cf-0905-4dfd-b13c-52991d257ac7)

 In addition, too much data processing should be avoided in the render function, otherwise performance will be affected. Therefore, I extracted the data processing part of the menus and the calling part of the reducer in the render method as a function.

2. When setting the inline style of an element, change the hyphen naming convention to the camel naming convention.

3. Comment out some redundant code.
