### PR TITLE
fix: fix locale switching bug

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -216,6 +216,7 @@ class BasicLayout extends React.PureComponent {
       type: "global/changeLanguage",
       payload: value
     });
+    this.processMenus()
   };
 
   processMenus() {


### PR DESCRIPTION
In my last PR(https://github.com/apache/shenyu-dashboard/pull/335), I extracted the data processing logic of the menu from the render function, which resulted in the locale switching not being reflected in the sidebar in time. This bug is fixed in this PR.