### PR TITLE
Improving the operational experience of document pages

### DIFF
--- a/src/routes/Document/components/SearchApi.js
+++ b/src/routes/Document/components/SearchApi.js
@@ -116,7 +116,7 @@ const SearchApi = React.forwardRef((props, ref) => {
       ) : (
         <>
           <Text code>{Method[item.httpMethod]}</Text>
-          <Tooltip title={item.apiPath}>{item.apiPath}</Tooltip>
+          <Tooltip placement="topLeft" arrowPointAtCenter title={item.apiPath}>{item.apiPath}</Tooltip>
         </>
       ),
       key: `${eventKey}-${index}`,
@@ -222,7 +222,7 @@ const SearchApi = React.forwardRef((props, ref) => {
       allNodes[curNodeIdx].title = (
         <>
           <Text code>{Method[data.httpMethod]}</Text>
-          <Tooltip title={data.apiPath}>{data.apiPath}</Tooltip>
+          <Tooltip placement="topLeft" arrowPointAtCenter title={data.apiPath}>{data.apiPath}</Tooltip>
         </>
       )
     }


### PR DESCRIPTION
Before: 
**Moving the mouse from bottom to top, the upper item will be obscured by the tooltip below, affecting the operation**
![before](https://github.com/apache/shenyu-dashboard/assets/3371163/cb2f6082-c659-4da8-8fe8-183b1ea1c55f)

After:
**Move the tooltip below to the back so that it does not completely cover the item above**
![after](https://github.com/apache/shenyu-dashboard/assets/3371163/904a9c93-b13f-4e82-8abc-04bb7aa36107)
