### PR TITLE
Fixed the exception of duplicate request headers on the api-debug page

### DIFF
--- a/src/routes/Document/components/ApiDebug.js
+++ b/src/routes/Document/components/ApiDebug.js
@@ -50,6 +50,21 @@ const arrayToObject = (arr) => {
   }, {});
 }
 
+const mergeArrays = (arr1, arr2) => {
+  let mergedArray = [...arr1];
+
+  arr2.forEach(item2 => {
+    let item1 = mergedArray.find(item => item.key === item2.key);
+    if (item1) {
+      item1.value = item2.value;
+    } else {
+      mergedArray.push(item2);
+    }
+  });
+
+  return mergedArray;
+}
+
 const FCForm = forwardRef(({ form, onSubmit }, ref) => {
   useImperativeHandle(ref, () => ({
     form
@@ -208,7 +223,7 @@ const FCForm = forwardRef(({ form, onSubmit }, ref) => {
   const changeParamTab = (key) => {
     setActiveKey(key);
     let header = form.getFieldsValue().headers;
-    let headerJson = [...JSON.parse(header), ...getDefaultHeaderByKey(key)];
+    let headerJson = mergeArrays(JSON.parse(header), getDefaultHeaderByKey(key));
     setInitialValue({...initialValue, header: JSON.stringify(headerJson)});
   }
 


### PR DESCRIPTION
Before:
![before](https://github.com/apache/shenyu-dashboard/assets/3371163/6b93744c-c8a7-46ce-be54-5f6185698854)

After:
![after](https://github.com/apache/shenyu-dashboard/assets/3371163/0344a32d-dae5-404c-a45c-409e0e6d00e0)
