### PR TITLE
[Improve] fetch data at componentDidMount

### DIFF
--- a/src/routes/System/Alert/index.js
+++ b/src/routes/System/Alert/index.js
@@ -38,7 +38,7 @@ export default class Alert extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.getAllAlerts();
   }
 


### PR DESCRIPTION
#341 

see: https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data

> The above code is problematic for both server rendering (where the external data won’t be used) and the upcoming async rendering mode (where the request might be initiated multiple times).
> 
> The recommended upgrade path for most use cases is to move data-fetching into componentDidMount