### PR TITLE
[Optimization] Optimizing PromiseRender.js Deprecated React Lifecycle

### DIFF
--- a/src/components/Authorized/PromiseRender.js
+++ b/src/components/Authorized/PromiseRender.js
@@ -21,15 +21,26 @@ import { Spin } from 'antd';
 export default class PromiseRender extends React.PureComponent {
   state = {
     component: null,
+    prevPropsPromise: null,
   };
 
   componentDidMount() {
     this.setRenderComponent(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    // new Props enter
-    this.setRenderComponent(nextProps);
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.promise !== prevState.prevPropsPromise) {
+      return {
+        prevPropsPromise: nextProps.promise,
+      };
+    }
+    return null;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.promise !== prevProps.promise) {
+      this.setRenderComponent(this.props);
+    }
   }
 
   // set render Component : ok or error


### PR DESCRIPTION
see: https://github.com/apache/shenyu-dashboard/issues/341

see: https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data-when-props-change

> The recommended upgrade path for this component is to move data updates into componentDidUpdate. You can also use the new getDerivedStateFromProps lifecycle to clear stale data before rendering the new props