### PR TITLE
fix: fix AuthRoute bug

### DIFF
--- a/src/utils/AuthRoute.js
+++ b/src/utils/AuthRoute.js
@@ -312,7 +312,7 @@ export default class AuthRoute extends Component {
       redirectPath,
       location: { pathname }
     } = this.props;
-    if (loading) {
+    if (loading || Object.keys(permissions).length === 0) {
       return (
         <Spin
           tip="Loading..."


### PR DESCRIPTION
related to: https://github.com/apache/shenyu-dashboard/issues/350

In some code development standards, it is not recommended to call asynchronous functions to obtain data in the constructor method, so I solved this bug again.

I found that the problem was that the method of obtaining permissions data was asynchronous. Before the permissions were obtained, the page was rendered empty, which caused an error. Therefore, I added a logic to handle null values on the original code.