### PR TITLE
fix: fix the bug that caused the plugin list to disappear after refreshing it

### DIFF
--- a/src/utils/AuthRoute.js
+++ b/src/utils/AuthRoute.js
@@ -17,7 +17,6 @@
 
 import React, { Component } from "react";
 import { connect } from "dva";
-import { Redirect } from "react-router-dom";
 import { Route } from "dva/router";
 import { Spin } from "antd";
 import { filterTree } from "./utils";
@@ -312,7 +311,7 @@ export default class AuthRoute extends Component {
       redirectPath,
       location: { pathname }
     } = this.props;
-    if (loading || Object.keys(permissions).length === 0) {
+    if (loading) {
       return (
         <Spin
           tip="Loading..."
@@ -328,7 +327,7 @@ export default class AuthRoute extends Component {
         return <Route path={path} component={component} />;
       } else {
         return (
-          <Route render={() => <Redirect to={{ pathname: redirectPath }} />} />
+          <Route path={redirectPath} component={null} />
         );
       }
     }


### PR DESCRIPTION
![image](https://github.com/apache/shenyu-dashboard/assets/116816752/2353bd50-fe8f-4274-82e3-89948cdd3ad0)

I found that the root cause of the error was an incorrect redirection statement in the original code, so I fixed it.

