### PR TITLE
[Fix] Fix selector handler display bug

### DIFF
--- a/src/routes/Plugin/Common/Selector.js
+++ b/src/routes/Plugin/Common/Selector.js
@@ -93,7 +93,7 @@ class AddModal extends Component {
     this.initDics();
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { dispatch, pluginId, handle, multiSelectorHandle } = this.props;
     this.setState({ pluginHandleList: [] });
     let type = 1;
@@ -214,6 +214,13 @@ class AddModal extends Component {
                 delete values.divideUpstreams;
                 delete values.gray;
                 delete values.key;
+              } else if (item.dataType === 3 && item.dictOptions) {
+                handle[index][item.field] = values[item.field + index] === "true"
+                    ? true
+                    : values[item.field + index] === "false"
+                        ? false
+                        : values[item.field + index];
+                delete values[item.field + index];
               } else {
                 handle[index][item.field] = values[item.field + index];
                 delete values[item.field + index];
@@ -571,7 +578,7 @@ class AddModal extends Component {
                               : item.defaultValue === "false"
                                 ? false
                                 : item.defaultValue);
-                        let placeholder = item.placeholder || item.label;
+                        let placeholder = item.label || item.placeholder;
                         let checkRule = item.checkRule;
                         let fieldName = item.field + index;
                         let rules = [];
@@ -601,8 +608,8 @@ class AddModal extends Component {
                                     rules,
                                     initialValue: defaultValue
                                   })(
-                                    <InputNumber
-                                      precision={0}
+                                    <Input
+                                      allowClear
                                       addonBefore={
                                         <div style={{ width: labelWidth }}>
                                           {item.label}
@@ -623,23 +630,17 @@ class AddModal extends Component {
                                 <Item>
                                   {getFieldDecorator(fieldName, {
                                     rules,
-                                    initialValue: defaultValue
+                                    initialValue: defaultValue.toString()
                                   })(
                                     <Select
-                                      placeholder={placeholder}
+                                      placeholder={defaultValue.toString()}
                                       style={{ width: "100%" }}
                                     >
                                       {item.dictOptions.map(option => {
                                         return (
                                           <Option
                                             key={option.dictValue}
-                                            value={
-                                              option.dictValue === "true"
-                                                ? true
-                                                : option.dictValue === "false"
-                                                  ? false
-                                                  : option.dictValue
-                                            }
+                                            value={option.dictValue}
                                           >
                                             {option.dictName} ({item.label})
                                           </Option>
@@ -654,7 +655,7 @@ class AddModal extends Component {
                         } else {
                           return (
                             <li key={fieldName}>
-                              <Tooltip title={item.value}>
+                              <Tooltip title={item.label}>
                                 <Item>
                                   {getFieldDecorator(fieldName, {
                                     rules,

--- a/src/routes/Plugin/Common/Selector.js
+++ b/src/routes/Plugin/Common/Selector.js
@@ -39,6 +39,7 @@ import classnames from "classnames";
 import styles from "../index.less";
 import { getIntlContent } from "../../../utils/IntlUtils";
 import SelectorCopy from "./SelectorCopy";
+import { parseBooleanString } from "../../../utils/utils";
 
 const { Item } = Form;
 const { Option } = Select;
@@ -215,11 +216,7 @@ class AddModal extends Component {
                 delete values.gray;
                 delete values.key;
               } else if (item.dataType === 3 && item.dictOptions) {
-                handle[index][item.field] = values[item.field + index] === "true"
-                    ? true
-                    : values[item.field + index] === "false"
-                        ? false
-                        : values[item.field + index];
+                handle[index][item.field] = parseBooleanString(values[item.field + index]);
                 delete values[item.field + index];
               } else {
                 handle[index][item.field] = values[item.field + index];

--- a/src/routes/Plugin/Discovery/ProxySelectorModal.js
+++ b/src/routes/Plugin/Discovery/ProxySelectorModal.js
@@ -17,7 +17,7 @@
 
 import React, {Component} from "react";
 import {connect} from "dva";
-import {Button, Col, Divider, Form, Input, InputNumber, Modal, Row, Select, Table, Tabs, Tooltip} from "antd";
+import {Button, Col, Divider, Form, Input, Modal, Row, Select, Table, Tabs, Tooltip} from "antd";
 import classnames from "classnames";
 import {getIntlContent} from "../../../utils/IntlUtils";
 import EditableTable from './UpstreamTable';
@@ -124,7 +124,15 @@ class ProxySelectorModal extends Component {
         handleResult[0] = {};
         if(Object.keys(pluginHandleList).length > 0){
           pluginHandleList[0].forEach(item => {
-            handleResult[0][item.field] = values[item.field + 0];
+            if (item.dataType === 3 && item.dictOptions) {
+              handleResult[0][item.field] = values[item.field + 0] === "true"
+                  ? true
+                  : values[item.field + 0] === "false"
+                      ? false
+                      : values[item.field + 0];
+            } else {
+              handleResult[0][item.field] = values[item.field + 0];
+            }
           });
         }
         handler = JSON.stringify(handler);
@@ -342,8 +350,8 @@ class ProxySelectorModal extends Component {
                                           rules,
                                           initialValue: defaultValue
                                         })(
-                                          <InputNumber
-                                            precision={0}
+                                          <Input
+                                            allowClear
                                             disabled={!isAdd}
                                             addonBefore={
                                               <div style={{ width: labelWidth }}>
@@ -365,24 +373,18 @@ class ProxySelectorModal extends Component {
                                       <FormItem>
                                         {getFieldDecorator(fieldName, {
                                           rules,
-                                          initialValue: defaultValue
+                                          initialValue: defaultValue.toString()
                                         })(
                                           <Select
                                             disabled={!isAdd}
-                                            placeholder={placeholder}
+                                            placeholder={placeholder.toString()}
                                             style={{ width: 260 }}
                                           >
                                             {item.dictOptions.map(option => {
                                               return (
                                                 <Option
                                                   key={option.dictValue}
-                                                  value={
-                                                    option.dictValue === "true"
-                                                      ? true
-                                                      : option.dictValue === "false"
-                                                        ? false
-                                                        : option.dictValue
-                                                  }
+                                                  value={option.dictValue}
                                                 >
                                                   {option.dictName} ({item.label})
                                                 </Option>

--- a/src/routes/Plugin/Discovery/ProxySelectorModal.js
+++ b/src/routes/Plugin/Discovery/ProxySelectorModal.js
@@ -23,7 +23,7 @@ import {getIntlContent} from "../../../utils/IntlUtils";
 import EditableTable from './UpstreamTable';
 import styles from "../index.less";
 import ProxySelectorCopy from "./ProxySelectorCopy.js";
-import {findKeyByValue} from "../../../utils/utils";
+import {findKeyByValue, parseBooleanString} from "../../../utils/utils";
 
 
 const FormItem = Form.Item;
@@ -125,11 +125,7 @@ class ProxySelectorModal extends Component {
         if(Object.keys(pluginHandleList).length > 0){
           pluginHandleList[0].forEach(item => {
             if (item.dataType === 3 && item.dictOptions) {
-              handleResult[0][item.field] = values[item.field + 0] === "true"
-                  ? true
-                  : values[item.field + 0] === "false"
-                      ? false
-                      : values[item.field + 0];
+              handleResult[0][item.field] = parseBooleanString(values[item.field + 0]);
             } else {
               handleResult[0][item.field] = values[item.field + 0];
             }

--- a/src/routes/Plugin/Discovery/index.js
+++ b/src/routes/Plugin/Discovery/index.js
@@ -230,7 +230,7 @@ export default class TCPProxy extends Component {
 
   editClick = () => {
     const {dispatch, plugins} = this.props;
-    const {pluginName} = this.props;
+    const {pluginName} = this.state;
     const plugin = this.getPlugin(plugins, pluginName);
     getUpdateModal({
       pluginId: plugin.id,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -194,3 +194,14 @@ export function formatTimestamp(timestamp) {
 export function findKeyByValue(obj, value) {
   return Object.keys(obj).find(key => obj[key] === value);
 }
+
+export function parseBooleanString(str) {
+  if (str.toLowerCase() === 'true') {
+    return true;
+  } else if (str.toLowerCase() === 'false') {
+    return false;
+  }
+  return str;
+}
+
+


### PR DESCRIPTION
This PR mainly made the following changes:
1. Fix selector handler display bug
before:
![image](https://github.com/apache/shenyu-dashboard/assets/116816752/e66b3cf9-4fbc-406c-a708-839bdf94bbf2)
after:
<img width="1487" alt="截屏2023-10-22 18 23 52" src="https://github.com/apache/shenyu-dashboard/assets/116816752/bd754ae9-da39-4cb3-86d4-db51a487b174">

2. Fix TCP plugin status edit bug
3. Optimize the abandoned life cycle method in the selector component (related to issue https://github.com/apache/shenyu-dashboard/issues/341)
