### PR TITLE
[Fix] Optimizing api tag delete operation

### DIFF
--- a/src/routes/Document/ApiDoc.js
+++ b/src/routes/Document/ApiDoc.js
@@ -121,6 +121,7 @@ function ApiDoc() {
       message.success(msg);
       if (tagDetail.id) {
         searchApiRef.current?.updateTree(null, 'tag');
+        setTagDetail({});
       }
       if (apiDetail.id) {
         searchApiRef.current?.updateTree(null, 'api');

--- a/src/routes/Document/components/SearchApi.js
+++ b/src/routes/Document/components/SearchApi.js
@@ -64,6 +64,9 @@ const SearchApi = React.forwardRef((props, ref) => {
       // 默认选中第一个
       setSelectedKeys(["0"]);
       onSelect(["0"], { node: { props: arr[0] } })
+    } else {
+      setTreeData(arr);
+      setSelectedKeys([]);
     }
   };
 

--- a/src/routes/Document/components/TagInfo.js
+++ b/src/routes/Document/components/TagInfo.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Typography, Button, Row, Col, Table } from "antd";
+import {Typography, Button, Row, Col, Table, Popconfirm} from "antd";
 import React, { useContext } from "react";
 import dayjs from "dayjs";
 import ApiContext from "./ApiContext";
@@ -80,9 +80,23 @@ function TagInfo(props) {
           {getIntlContent("SHENYU.BUTTON.SYSTEM.EDIT")}
         </Button>
         &nbsp;&nbsp;
-        <Button ghost type="danger" onClick={handleDelete}>
-          {getIntlContent("SHENYU.BUTTON.SYSTEM.DELETE")}
-        </Button>
+        <Popconfirm
+          title={getIntlContent("SHENYU.COMMON.DELETE")}
+          placement="bottom"
+          onCancel={e => {
+            e.stopPropagation();
+          }}
+          onConfirm={e => {
+            e.stopPropagation();
+            handleDelete(e)
+          }}
+          okText={getIntlContent("SHENYU.COMMON.SURE")}
+          cancelText={getIntlContent("SHENYU.COMMON.CALCEL")}
+        >
+          <Button ghost type="danger">
+            {getIntlContent("SHENYU.BUTTON.SYSTEM.DELETE")}
+          </Button>
+        </Popconfirm>
       </Col>
       <Col span={12}>
         <Text>


### PR DESCRIPTION
1. Upon deleting an API tag, trigger a Popconfirm.

2. When all API tags are removed, refresh the tag information.