### PR TITLE
[Fix] Fix the selector display bug when the discovery props are null

### DIFF
--- a/src/routes/Plugin/Common/Rule.js
+++ b/src/routes/Plugin/Common/Rule.js
@@ -541,7 +541,7 @@ class AddModal extends Component {
               <strong>*</strong>
               {getIntlContent("SHENYU.COMMON.CONDITION")}:
             </h3>
-            <div className={styles.content}>
+            <div className={styles.content} style={{ marginLeft: '2%' }}>
               {ruleConditions.map((item, index) => {
                 return (
                   <ul key={index}>

--- a/src/routes/Plugin/Common/index.js
+++ b/src/routes/Plugin/Common/index.js
@@ -380,11 +380,11 @@ export default class Common extends Component {
       callback: selector => {
        if ( isDiscovery ){
         let discoveryConfig = {
-          props: selector.discoveryVO ? selector.discoveryVO.props: "{}",
-          discoveryType: selector.discoveryVO ? selector.discoveryVO.type: 'local',
-          serverList: selector.discoveryVO ? selector.discoveryVO.serverList: '',
-          handler: selector.discoveryHandler ? selector.discoveryHandler.handler: "{}",
-          listenerNode: selector.discoveryHandler ? selector.discoveryHandler.listenerNode : '',
+          props: selector.discoveryVO && selector.discoveryVO.props ? selector.discoveryVO.props: "{}",
+          discoveryType: selector.discoveryVO && selector.discoveryVO.type ? selector.discoveryVO.type: 'local',
+          serverList: selector.discoveryVO && selector.discoveryVO.serverList ? selector.discoveryVO.serverList: '',
+          handler: selector.discoveryHandler && selector.discoveryHandler.handler ? selector.discoveryHandler.handler: "{}",
+          listenerNode: selector.discoveryHandler && selector.discoveryHandler.listenerNode ? selector.discoveryHandler.listenerNode : '',
         }
         let updateArray = [];
         if (selector.discoveryUpstreams) {


### PR DESCRIPTION
Based on feedback from our community contributor, it was observed that the selector was displaying errors when props were set to null, as depicted in the attached screenshot.

![image](https://github.com/apache/shenyu-dashboard/assets/116816752/5b93313a-064e-4a51-b528-53d7d61736d0)


This PR addresses the issue by implementing a fix to handle cases where props are null, ensuring a smoother user experience.