### PR TITLE
Fix exception styles

### DIFF
--- a/src/routes/System/AppAuth/SearchContent.js
+++ b/src/routes/System/AppAuth/SearchContent.js
@@ -33,7 +33,7 @@ class InlineSearch extends React.Component {
   render() {
     const { getFieldDecorator } = this.props.form;
     return (
-      <Form layout="inline" onSubmit={this.handleSubmit}>
+      <Form layout="inline" onSubmit={this.handleSubmit} className={styles.form}>
         <Form.Item className={styles.formInput}>
           {getFieldDecorator('appKey', {
             initialValue: null
@@ -55,7 +55,7 @@ class InlineSearch extends React.Component {
             />,
           )}
         </Form.Item>
-        <Form.Item className={styles.formItem}>
+        <Form.Item className={styles.formBtn}>
           <AuthButton perms="system:authen:list">
             <Button type="primary" htmlType="submit">
               {getIntlContent("SHENYU.SYSTEM.SEARCH")}

--- a/src/routes/System/AppAuth/index.less
+++ b/src/routes/System/AppAuth/index.less
@@ -61,10 +61,16 @@
   }
 }
 
+.form {
+  :global(.ant-form-item-control) {
+    line-height: inherit !important;
+  }
+}
+
 .formInput {
   width: 175px;
 }
 
-.formItem {
+.formBtn {
   margin-right: 0px !important;
 }


### PR DESCRIPTION
BEFORE:
![e8bb91f5c84c7be9c0d8d1fb6d6db85](https://github.com/apache/shenyu-dashboard/assets/3371163/3b4e17a1-5db9-404b-bda8-1f43238a9387)
Because the former part uses the form component, which internally defines the value of independent line-height; resulting in inconsistency with the line-height of the latter part, the whole looks visually uncentered.

AFTER:
![5654d55508046a8e421fc430473838c](https://github.com/apache/shenyu-dashboard/assets/3371163/469d454e-7e26-4e1a-9272-67827858d3f7)
Erasing the custom line-height of the former part, so that the whole has a uniform line-height, and finally achieves visual centering.