### PR TITLE
Added global back to top button

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { routerRedux, Route, Switch } from "dva/router";
-import { ConfigProvider } from "antd";
+import { ConfigProvider, BackTop } from "antd";
 import enUS from "antd/lib/locale-provider/en_US";
 import { getRouterData } from "./common/router";
 import AuthRoute from "./utils/AuthRoute";
@@ -41,6 +41,7 @@ function RouterConfig({ history, app }) {
           />
         </Switch>
       </ConnectedRouter>
+      <BackTop />
     </ConfigProvider>
   );
 }

--- a/src/routes/Document/ApiDoc.js
+++ b/src/routes/Document/ApiDoc.js
@@ -17,7 +17,7 @@
 
 /* eslint-disable no-unused-expressions */
 /* eslint-disable react/jsx-no-constructed-context-values */
-import { Col, Row, Card, BackTop, Empty, message } from "antd";
+import { Col, Row, Card, Empty, message } from "antd";
 import React, { useEffect, useState } from "react";
 import {
   getApi,
@@ -194,7 +194,6 @@ function ApiDoc() {
           </Card>
         </Col>
       </Row>
-      <BackTop />
     </ApiContext.Provider>
   );
 }


### PR DESCRIPTION
Before:
![backtop1](https://github.com/apache/shenyu-dashboard/assets/3371163/d91cf333-20cd-4548-b798-4ea149825ce7)

After:
![backtop2](https://github.com/apache/shenyu-dashboard/assets/3371163/88e41b11-0f93-427f-a999-65c27d2fe6eb)

**Previously, the back to top button existed only on document pages, now move it to global**