### PR TITLE
[type:fix] Correct Plugin ID Query in Namespace Plugin Edit Page

### DIFF
--- a/src/routes/System/NamespacePlugin/index.js
+++ b/src/routes/System/NamespacePlugin/index.js
@@ -143,7 +143,7 @@ export default class NamespacePlugin extends Component {
   editClick = (record) => {
     const { dispatch, currentNamespaceId } = this.props;
     getUpdateModal({
-      id: record.id,
+      pluginId: record.pluginId,
       namespaceId: currentNamespaceId,
       dispatch,
       fetchValue: this.currentQueryPayload(),
@@ -231,13 +231,18 @@ export default class NamespacePlugin extends Component {
 
   // 批量启用或禁用
   enableClick = () => {
-    const { dispatch, currentNamespaceId } = this.props;
+    const {
+      dispatch,
+      currentNamespaceId,
+      namespacePlugin: { namespacePluginList },
+    } = this.props;
     const { selectedRowKeys } = this.state;
     if (selectedRowKeys && selectedRowKeys.length > 0) {
       dispatch({
         type: "namespacePlugin/fetchItem",
         payload: {
-          id: selectedRowKeys[0],
+          pluginId: namespacePluginList.find((i) => i.id === selectedRowKeys[0])
+            ?.pluginId,
           namespaceId: currentNamespaceId,
         },
         callback: (user) => {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1174,7 +1174,7 @@ export async function deleteNamespace(params) {
 /* findNamespacePlugin */
 export async function findNamespacePlugin(params) {
   return request(
-    `${baseUrl}/namespacePlugin/id=${params.id}&namespaceId=${params.namespaceId}`,
+    `${baseUrl}/namespacePlugin/pluginId=${params.pluginId}&namespaceId=${params.namespaceId}`,
     {
       method: `GET`,
     },

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1174,7 +1174,7 @@ export async function deleteNamespace(params) {
 /* findNamespacePlugin */
 export async function findNamespacePlugin(params) {
   return request(
-    `${baseUrl}/namespacePlugin/pluginId=${params.pluginId}&namespaceId=${params.namespaceId}`,
+    `${baseUrl}/namespacePlugin/${params.pluginId}/${params.namespaceId}`,
     {
       method: `GET`,
     },

--- a/src/utils/namespacePlugin.js
+++ b/src/utils/namespacePlugin.js
@@ -20,7 +20,7 @@ import { refreshAuthMenus } from "./AuthRoute";
 import AddModal from "../routes/System/NamespacePlugin/AddModal";
 
 export function getUpdateModal({
-  id,
+  pluginId,
   namespaceId,
   dispatch,
   fetchValue,
@@ -31,7 +31,7 @@ export function getUpdateModal({
   dispatch({
     type: "namespacePlugin/fetchItem",
     payload: {
-      id,
+      pluginId,
       namespaceId,
     },
     callback: (plugin) => {


### PR DESCRIPTION
This PR fixes the issue where the plugin edit page could not be opened due to an incorrect query. The request GET /namespacePlugin/id={id}&namespaceId={namespaceId} was using pluginId = {id} for querying, resulting in a failure to retrieve the necessary data. The service method org.apache.shenyu.admin.service.NamespacePluginService#findById has been refactored to findByPluginId, and the frontend has been updated accordingly to use pluginId in the "namespacePlugin/fetchItem" request.

Moreover, the plugin_id field in the plugin_ns_rel table has been updated from a numeric type to VARCHAR(128) to ensure type consistency. Note that bulk operations like delete and enable/disable still use id as the query condition. This PR might be related to the recent changes in the namespace feature. CC: @xcsnx