### PR TITLE
fix divide plugin: localizes status labels.

### DIFF
--- a/src/routes/Plugin/Discovery/DiscoveryUpstreamTable.js
+++ b/src/routes/Plugin/Discovery/DiscoveryUpstreamTable.js
@@ -40,8 +40,8 @@ class EditableCell extends Component {
       // return <Select />;
       return (
         <Select>
-          <Option value="0">open</Option>
-          <Option value="1">close</Option>
+          <Option value={0}>{getIntlContent("SHENYU.COMMON.OPEN")}</Option>
+          <Option value={1}>{getIntlContent("SHENYU.COMMON.CLOSE")}</Option>
         </Select>
       );
     } else if (this.props.inputType === "switch") {
@@ -67,24 +67,24 @@ class EditableCell extends Component {
           <Form.Item style={{ margin: 0 }}>
             {dataIndex === "gray"
               ? getFieldDecorator(dataIndex, {
-                  rules: [
-                    {
-                      required: true,
-                      message: `Please Input ${title}!`,
-                    },
-                  ],
-                  valuePropName: "checked",
-                  initialValue: record[dataIndex],
-                })(this.getInput())
+                rules: [
+                  {
+                    required: true,
+                    message: `Please Input ${title}!`,
+                  },
+                ],
+                valuePropName: "checked",
+                initialValue: record[dataIndex],
+              })(this.getInput())
               : getFieldDecorator(dataIndex, {
-                  rules: [
-                    {
-                      required: true,
-                      message: `Please Input ${title}!`,
-                    },
-                  ],
-                  initialValue: record[dataIndex],
-                })(this.getInput())}
+                rules: [
+                  {
+                    required: true,
+                    message: `Please Input ${title}!`,
+                  },
+                ],
+                initialValue: dataIndex === "status" ? Number(record[dataIndex]) : record[dataIndex],
+              })(this.getInput())}
           </Form.Item>
         ) : (
           children
@@ -129,7 +129,15 @@ class EditableTable extends Component {
         width: "19%",
         align: "center",
         render: (text) => {
-          return text === 0 || text === "0" ? "open" : "close";
+          const statusMap = {
+            0: getIntlContent("SHENYU.COMMON.OPEN"),
+            1: getIntlContent("SHENYU.COMMON.CLOSE"),
+            false: getIntlContent("SHENYU.COMMON.OPEN"),
+            true: getIntlContent("SHENYU.COMMON.CLOSE"),
+            "false": getIntlContent("SHENYU.COMMON.OPEN"),
+            "true": getIntlContent("SHENYU.COMMON.CLOSE")
+          };
+          return statusMap[text] || getIntlContent("SHENYU.COMMON.CLOSE");
         },
       },
       {

--- a/src/routes/Plugin/Discovery/DiscoveryUpstreamTable.js
+++ b/src/routes/Plugin/Discovery/DiscoveryUpstreamTable.js
@@ -67,24 +67,27 @@ class EditableCell extends Component {
           <Form.Item style={{ margin: 0 }}>
             {dataIndex === "gray"
               ? getFieldDecorator(dataIndex, {
-                rules: [
-                  {
-                    required: true,
-                    message: `Please Input ${title}!`,
-                  },
-                ],
-                valuePropName: "checked",
-                initialValue: record[dataIndex],
-              })(this.getInput())
+                  rules: [
+                    {
+                      required: true,
+                      message: `Please Input ${title}!`,
+                    },
+                  ],
+                  valuePropName: "checked",
+                  initialValue: record[dataIndex],
+                })(this.getInput())
               : getFieldDecorator(dataIndex, {
-                rules: [
-                  {
-                    required: true,
-                    message: `Please Input ${title}!`,
-                  },
-                ],
-                initialValue: dataIndex === "status" ? Number(record[dataIndex]) : record[dataIndex],
-              })(this.getInput())}
+                  rules: [
+                    {
+                      required: true,
+                      message: `Please Input ${title}!`,
+                    },
+                  ],
+                  initialValue:
+                    dataIndex === "status"
+                      ? Number(record[dataIndex])
+                      : record[dataIndex],
+                })(this.getInput())}
           </Form.Item>
         ) : (
           children
@@ -134,8 +137,6 @@ class EditableTable extends Component {
             1: getIntlContent("SHENYU.COMMON.CLOSE"),
             false: getIntlContent("SHENYU.COMMON.OPEN"),
             true: getIntlContent("SHENYU.COMMON.CLOSE"),
-            "false": getIntlContent("SHENYU.COMMON.OPEN"),
-            "true": getIntlContent("SHENYU.COMMON.CLOSE")
           };
           return statusMap[text] || getIntlContent("SHENYU.COMMON.CLOSE");
         },


### PR DESCRIPTION
Replaces hardcoded status options with localized content using `getIntlContent` for better internationalization.

Adjusts initial value handling for form fields and refines status rendering logic to ensure consistency.

Improves maintainability and prepares the application for multi-language support.