### PR TITLE
fix:UI bug on smaller screen sizes #530

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -91,7 +91,7 @@ ol {
   align-items: center;
   justify-content: space-between;
   line-height: 40px;
-  padding: 0 20px;
+  padding: 0 10px;
   border-radius: 5px;
   box-shadow: 1px 2px 2px rgba(191, 189, 189, 0.5);
   height: 40px;

--- a/src/routes/Plugin/Common/index.js
+++ b/src/routes/Plugin/Common/index.js
@@ -1172,8 +1172,8 @@ export default class Common extends Component {
         </Row>
         <Row gutter={20}>
           <Col span={10}>
+            <h3>{getIntlContent("SHENYU.PLUGIN.SELECTOR.LIST.TITLE")}</h3>
             <div className="table-header">
-              <h3>{getIntlContent("SHENYU.PLUGIN.SELECTOR.LIST.TITLE")}</h3>
               <div className={styles.headerSearch}>
                 <AuthButton perms={`plugin:${name}Selector:query`}>
                   <Search
@@ -1246,9 +1246,10 @@ export default class Common extends Component {
             />
           </Col>
           <Col span={14}>
+            <h3>{getIntlContent("SHENYU.PLUGIN.SELECTOR.RULE.LIST")}</h3>
+
             <div className="table-header">
               <div style={{ display: "flex", alignItems: "center" }}>
-                <h3>{getIntlContent("SHENYU.PLUGIN.SELECTOR.RULE.LIST")}</h3>
                 <AuthButton perms={`plugin:${name}:modify`}>
                   <Button
                     icon="reload"
@@ -1260,7 +1261,7 @@ export default class Common extends Component {
                 </AuthButton>
               </div>
 
-              <div className={styles.headerSearch}>
+              <div className={`${styles.headerSearch} ${styles.marginLeft10}`}>
                 <AuthButton perms={`plugin:${name}Rule:query`}>
                   <Search
                     className={styles.search}

--- a/src/routes/Plugin/index.less
+++ b/src/routes/Plugin/index.less
@@ -23,7 +23,6 @@
 .headerSearch {
   display: flex;
   justify-content: space-between;
-  margin-left: 10px;
   align-items: center;
 
   .search {
@@ -31,6 +30,9 @@
     display: flex;
     align-items: center;
   }
+}
+.marginLeft10{
+  margin-left: 10px;
 }
 
 .condition, .springCloud {


### PR DESCRIPTION
I divided the title and operation buttons into two lines and modified the style to solve the problem of button overflow under the small screen.

 [bug address](https://github.com/apache/shenyu-dashboard/issues/530)
 
 The adjusted visual presentation：
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/be8e654d-d933-41a5-bb24-9e3e9b37e588" />
