### PR TITLE
fix: pass namespaceId when deleting discovery config

### DIFF
--- a/src/routes/Plugin/Discovery/index.js
+++ b/src/routes/Plugin/Discovery/index.js
@@ -513,10 +513,12 @@ export default class DiscoveryProxy extends Component {
 
   handleConfigDelete = (id) => {
     if (id !== undefined) {
+      const { currentNamespaceId } = this.props;
       this.props.dispatch({
         type: "discovery/deleteConfig",
         payload: {
           discoveryId: id,
+          namespaceId: currentNamespaceId,
         },
       });
     } else {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1134,12 +1134,14 @@ export function refreshProxySelector(params) {
 }
 
 export function deleteDiscovery(params) {
-  return request(`${baseUrl}/discovery/${params.discoveryId}`, {
-    method: `DELETE`,
-    body: {
-      ...params,
+  return request(
+    `${baseUrl}/discovery/${params.discoveryId}?${stringify({
+      namespaceId: params.namespaceId,
+    })}`,
+    {
+      method: `DELETE`,
     },
-  });
+  );
 }
 
 export function getAlertReceivers(params) {


### PR DESCRIPTION
The backend now requires `namespaceId` on `DELETE /discovery/{discoveryId}` (implemented as `@RequestParam`). Without it, deleting a discovery config from the UI returns 400.

- `handleConfigDelete` in the Discovery page now passes `namespaceId: currentNamespaceId` in the dispatch payload.
- `deleteDiscovery` sends `namespaceId` as a query param instead of a body.

`insertOrUpdate` already passes `namespaceId`, so it is unaffected.

related pr: [#7007](https://github.com/apache/shenyu/pull/7007)